### PR TITLE
Fix broken check for sensor ID

### DIFF
--- a/src/vl53l4cd_class.h
+++ b/src/vl53l4cd_class.h
@@ -130,7 +130,7 @@ class VL53L4CD {
 
       status = VL53L4CD_GetSensorId(&sensor_id);
 
-      if (status != VL53L4CD_ERROR_NONE && (sensor_id != 0xebaa)) {
+      if (status != VL53L4CD_ERROR_NONE || (sensor_id != 0xebaa)) {
         return VL53L4CD_ERROR_TIMEOUT;
       }
 


### PR DESCRIPTION
**Summary**

This PR fixes a bug that would make an incorrect sensor ID go unnoticed. This is because when the sensor ID is fetched successfully using `VL53L4CD_GetSensorId()` the first part of the following if clause evaluates to false because the return value will be `VL53L4CD_ERROR_NONE` which means the sensor ID is never checked. The sensor ID needs to be checked separately and return a dedicated error so it can be distinguished from a timeout error.
