### PR TITLE
Add alternative 0xecaa ID

### DIFF
--- a/src/vl53l4cd_class.h
+++ b/src/vl53l4cd_class.h
@@ -130,7 +130,7 @@ class VL53L4CD {
 
       status = VL53L4CD_GetSensorId(&sensor_id);
 
-      if (status != VL53L4CD_ERROR_NONE || (sensor_id != 0xebaa)) {
+      if (status != VL53L4CD_ERROR_NONE || ((sensor_id != 0xebaa) && (sensor_id != 0xecaa))) {
         return VL53L4CD_ERROR_TIMEOUT;
       }
 


### PR DESCRIPTION
Some sensors mounted on Plug And Play kit are reporting `0xecaa` as ID (may be a new silicon revision not tracked by the datasheet?)

The issue was not discovered before https://github.com/stm32duino/VL53L4CD/commit/d2c29d592c53898bf8fac64b71a76dab98840a69 got merged, since the check was succeeded in any case.

